### PR TITLE
dev/ic3: v3 writer

### DIFF
--- a/cfdtools/ic3/_ic3.py
+++ b/cfdtools/ic3/_ic3.py
@@ -31,6 +31,19 @@ ic3_restart_codes = {"UGP_IO_MAGIC_NUMBER":123581321,
                      "UGP_IO_DATA":50,
                      "UGP_IO_EOF":51,}
 
+properties_ugpcode = {
+    ic3_restart_codes["UGP_IO_FA_D1"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_FA_D3"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_NO_D1"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_NO_D3"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_CV_D1"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_CV_D3"]:  { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_CV_D33"]: { 'structcode': "d", 'size': 8, 'numpytype': np.float64 },
+    ic3_restart_codes["UGP_IO_FA_II1"]:  { 'structcode': "q", 'size': 8, 'numpytype': np.int64 },
+    ic3_restart_codes["UGP_IO_NO_II1"]:  { 'structcode': "q", 'size': 8, 'numpytype': np.int64 },
+    ic3_restart_codes["UGP_IO_CV_II1"]:  { 'structcode': "q", 'size': 8, 'numpytype': np.int64 },
+}
+
 # Dictionary to convert type of data [string] to a number of bytes for clean binary parsing
 type2nbytes = {"char":1,
                "int32":4,

--- a/cfdtools/ic3/writerV3.py
+++ b/cfdtools/ic3/writerV3.py
@@ -47,17 +47,21 @@ class writer(writer_v2):
             # Scalar
             if item.size == item.shape[0]:
                 # Header
+                api.io.print('std', '  write node scalar data '+key)
                 header = restartSectionHeader()
                 header.name = key
-                header.id = ic3_restart_codes["UGP_IO_NO_D1"]
-                header.skip = header.hsize + type2nbytes["float64"] * self.params["no_count"]
+                header.id = {"float64": ic3_restart_codes["UGP_IO_NO_D1"],
+                    "int64": ic3_restart_codes["UGP_IO_NO_II1"]}[item.dtype.name]
+                header.skip = header.hsize + item.itemsize * self.params["no_count"]
                 header.idata[0] = self.params["no_count"]
                 header.write(self.fid, self.endian)
                 # Field
-                BinaryWrite(self.fid, self.endian, "d"*self.params["no_count"], item)
+                chartype = properties_ugpcode[header.id]['structcode']
+                BinaryWrite(self.fid, self.endian, chartype*self.params["no_count"], item)
         for key, item in self.vars["nodes"].items():
             # Vector
             if len(item.shape) == 2:
+                api.io.print('std', '  write node vector data '+key)
                 # Header
                 header = restartSectionHeader()
                 header.name = key
@@ -75,7 +79,6 @@ class writer(writer_v2):
 
         # Then the cell based variables
         for key, item in self.vars["cells"].items():
-            api.io.print("  "+item.__str__())
             ndof = item.ndof()
             npdata = item.data()
             ncv = self.params["cv_count"]
@@ -83,15 +86,18 @@ class writer(writer_v2):
             # Scalar
             if npdata.size == npdata.shape[0]:
                 # Header
+                api.io.print('std', '  write cell scalar data '+key)
                 header = restartSectionHeader()
                 header.name = key
-                header.id = ic3_restart_codes["UGP_IO_CV_D1"]
-                header.skip = header.hsize + type2nbytes["float64"] * totsize
+                header.id = {"float64": ic3_restart_codes["UGP_IO_CV_D1"],
+                    "int64": ic3_restart_codes["UGP_IO_CV_II1"]}[npdata.dtype.name]
+                header.skip = header.hsize + type2nbytes[npdata.dtype.name] * totsize
                 header.idata[0] = ncv
                 header.idata[1] = ndof
                 header.write(self.fid, self.endian)
                 # Field
-                BinaryWrite(self.fid, self.endian, "d"*totsize, npdata)
+                chartype = properties_ugpcode[header.id]['structcode']
+                BinaryWrite(self.fid, self.endian, chartype*totsize, npdata)
         for key, item in self.vars["cells"].items():
             ndof = item.ndof()
             npdata = item.data()
@@ -99,6 +105,7 @@ class writer(writer_v2):
             # Vector
             if len(npdata.shape) == 2:
                 # Header
+                api.io.print('std', '  write cell vector data '+key)
                 header = restartSectionHeader()
                 header.name = key
                 header.id = ic3_restart_codes["UGP_IO_CV_D3"]
@@ -116,6 +123,7 @@ class writer(writer_v2):
             # Tensor
             if len(npdata.shape) == 3:
                 # Header
+                api.io.print('std', '  write cell tensor data '+key)
                 header = restartSectionHeader()
                 header.name = key
                 header.id = ic3_restart_codes["UGP_IO_CV_D33"]

--- a/docs/ic3-format.md
+++ b/docs/ic3-format.md
@@ -206,3 +206,16 @@ order of sections is arbitrary
 ### `NOOFA` face2node connectivity
 
 - header with number of nodes, faces and cells
+
+## parameters
+## variables and fieds
+
+Though the format can be read in any order. The current (v2 and v3) order in IC3 code is
+
+- scalars
+  - double float: nodes, faces, and cells
+  - long int: nodes, faces, and cells
+- vectors
+  - double float: nodes, faces, and cells
+- tensors
+  - double float: cells only


### PR DESCRIPTION
issue #3 
- reader_legacy is now able to read long int variable sections (node or cell indexed)
- v3 writer is able to write them

new connectivity in v3 involves long int arrays which are saved as variables
- `NODE_GB_INDEX`(node indexed)
- `CV_NODE_ROOT_0` and `CV_NODE_ROOT_1` (cell indexed)
reading and writing long int sections was necessary

v2 to v3 transfer is not yet available since it needs the creation of these arrays