### PR TITLE
Write an XDMF file along with the HDF5 file

### DIFF
--- a/cfdtools/data.py
+++ b/cfdtools/data.py
@@ -6,7 +6,6 @@ import cfdtools.hdf5 as hdf5
 
 
 class DataSetBase:
-
     _available_Xrep = ('nodal', 'cellaverage')
     _available_Trep = 'instant'
 
@@ -60,12 +59,13 @@ class DataSetBase:
 
     def set_nodes(self, x, y=None, z=None):
         self._geoprop['x'] = x
-        if y: self._geoprop['y'] = y
-        if z: self._geoprop['z'] = z
+        if y:
+            self._geoprop['y'] = y
+        if z:
+            self._geoprop['z'] = z
 
 
 class DataSet(DataSetBase):
-
     _available_Xrep = ('nodal', 'cellaverage', 'spectralcell')
     _available_Trep = ('instant', 'timeevol', 'spectrum', 'spectrogram')
 
@@ -105,17 +105,15 @@ class DataSet(DataSetBase):
 
     def dataSet_spectrum(self, datafilter=None, imin=None, imax=None):
         dtavg, dtdev, n = self.dtstats(imin, imax)  # check 'timeevol'
-        if dtdev / dtavg > 1.e-6:
-            api.io.warning(
-                f"dt standard deviation is significant: {dtdev / dtavg}"
-            )
+        if dtdev / dtavg > 1.0e-6:
+            api.io.warning(f"dt standard deviation is significant: {dtdev / dtavg}")
         f = fftm.fftfreq(n, dtavg)
         newdataset = DataSet(self.Xrep, self.ndof, Trep='spectrum')
         newdataset.add_data('freq', f)
         datalist = datafilter if datafilter else list(self.keys())
         datalist.remove('time')
         for name in datalist:
-            newdataset.add_data(name, np.abs(fftm.fft(self[name]-dtavg)))
+            newdataset.add_data(name, np.abs(fftm.fft(self[name] - dtavg)))
         return newdataset
 
     def dataSet_spectrogram(self, datafilter=None, window=None):
@@ -124,25 +122,26 @@ class DataSet(DataSetBase):
         datalist.remove('time')
         dtavg, dtdev, ntot = self.dtstats()  # check 'timeevol'
         # print(dtavg, dtdev)
-        if dtdev / dtavg > 1.e-6:
-            api.io.warning(
-                f"dt standard deviation is significant: {100*dtdev / dtavg:.4f}%"
-            )
+        if dtdev / dtavg > 1.0e-6:
+            api.io.warning(f"dt standard deviation is significant: {100*dtdev / dtavg:.4f}%")
         newdataset = DataSet(self.Xrep, self.ndof, Trep='spectrogram')
-        nwind = window if window else int(ntot/100)
-        hwin = int(nwind/2)
+        nwind = window if window else int(ntot / 100)
+        hwin = int(nwind / 2)
         f = fftm.fftfreq(nwind, dtavg)
-        newdataset.add_data('freq', f[lowcrop:hwin+1])
-        nit = int(2*ntot/nwind)-1
+        newdataset.add_data('freq', f[lowcrop : hwin + 1])
+        nit = int(2 * ntot / nwind) - 1
         newdataset.add_data('time', (self['time'][hwin::hwin])[:-1])
         for name in datalist:
-            v = np.zeros((nit, hwin+1-lowcrop))
+            v = np.zeros((nit, hwin + 1 - lowcrop))
             # print(ntot, nit, nwind, hwin, newdataset['freq'].shape, f.shape)
             for i in range(nit):
-                v[i,:] = np.log(np.abs(fftm.rfft(self[name][hwin*i:hwin*(i+2)+1]*np.hanning(2*hwin+1))))[lowcrop:]  
+                v[i, :] = np.log(
+                    np.abs(fftm.rfft(self[name][hwin * i : hwin * (i + 2) + 1] * np.hanning(2 * hwin + 1)))
+                )[lowcrop:]
             # print(v.shape, newdataset['freq'].shape, newdataset['time'].shape)
             newdataset.add_data(name, v)
         return newdataset
+
 
 # class manufactured_DataSet(DataSet):
 #
@@ -151,7 +150,6 @@ class DataSet(DataSetBase):
 
 
 class DataSetList(DataSetBase):
-
     _available_Xrep = ('nodal', 'cellaverage', 'spectralcell')
     _available_Trep = ('instant', 'timeevol', 'pod')
 
@@ -170,7 +168,7 @@ class DataSetList(DataSetBase):
         datalist.remove('time')
         dtavg, dtdev, ntot = self.dtstats()  # check 'timeevol'
         # print(dtavg, dtdev)
-        if dtdev / dtavg > 1.e-6:
+        if dtdev / dtavg > 1.0e-6:
             api.io.warning(f"dt standard deviation is significant: {100*dtdev / dtavg:.4f}%")
         newdataset = DataSet(self.Xrep, self.ndof, Trep='spectrogram')
         return newdataset
@@ -186,3 +184,37 @@ class DataSetList(DataSetBase):
             datagroup = hgroup.create_group(f"i{i:06}")
             for vname, var in datadict.items():
                 datagroup.create_dataset(vname, data=var, **options)
+
+    def xdmf_content(self, filename, geometry_content):
+        """Create the XMF content associated to the data set.
+
+        :param str filename: Name of the output HDF5 file.
+        :param list(str) geometry_content: XDMF content for the geometry and topology of the mesh.
+          The mesh is time-invariant.
+        :return: The XMF content.
+        :rtype: list(str)
+        """
+        lines = ['<Grid Name="IC3" GridType="Collection" CollectionType="Temporal">']
+
+        for i, datadict in enumerate(self._datalist):
+            lines += ['<Grid Name="Unstructured Mesh">']
+            lines += [f'<Time Value="{i}"/>']
+            lines += geometry_content
+            for vname, var in datadict.items():
+                if len(var.shape) == 1:
+                    typ = "Scalar"
+                elif len(var.shape) == 2:
+                    typ = "Vector"
+                else:
+                    raise ValueError(f"Type of data cannot be deduced with shape dimension {len(var.shape)}")
+                dim = " ".join(str(j) for j in var.shape)
+
+                lines += [f'<Attribute AttributeType="{typ}" Center="Cell" Name="{vname}">']
+                lines += [f'<DataItem Dimensions="{dim}" Format="HDF">']
+                lines += [f"{filename}:/datalist/i{i:06}/{vname}"]
+                lines += ["</DataItem>"]
+                lines += ["</Attribute>"]
+            lines += ["</Grid>"]
+        lines += ["</Grid>"]
+
+        return lines

--- a/cfdtools/data.py
+++ b/cfdtools/data.py
@@ -186,12 +186,12 @@ class DataSetList(DataSetBase):
                 datagroup.create_dataset(vname, data=var, **options)
 
     def xdmf_content(self, filename, geometry_content):
-        """Create the XMF content associated to the data set.
+        """Create the XDMF content associated to the data set.
 
         :param str filename: Name of the output HDF5 file.
         :param list(str) geometry_content: XDMF content for the geometry and topology of the mesh.
           The mesh is time-invariant.
-        :return: The XMF content.
+        :return: The XDMF content.
         :rtype: list(str)
         """
         lines = ['<Grid Name="IC3" GridType="Collection" CollectionType="Temporal">']

--- a/cfdtools/hdf5/_hdf5.py
+++ b/cfdtools/hdf5/_hdf5.py
@@ -3,13 +3,11 @@ from cfdtools.api import io, _files, error_stop
 
 try:
     import h5py
+    from h5py import Group  # to be available in _hdf5
 
     import_h5py = True
 except ImportError:
     import_h5py = False
-
-
-from h5py import Group  # to be available in _hdf5
 
 _available_types = ('external', 'dataset', 'datalist', 'probes', 'cfdmesh')
 
@@ -30,7 +28,7 @@ class h5File(_files):
         try:
             self._h5file = h5py.File(self._path, mode=mode)
         except NameError:
-            raise NameError(f'{self._path} can not be open in {mode} mode.')
+            raise NameError(f"{self._path} can not be open in {mode} mode.")
         if mode == 'w':
             assert datatype in _available_types
             self._h5file.attrs.update({'cfdtools_version': __version__, 'cfd_datatype': datatype})

--- a/cfdtools/hdf5/_hdf5.py
+++ b/cfdtools/hdf5/_hdf5.py
@@ -30,8 +30,7 @@ class h5File(_files):
         try:
             self._h5file = h5py.File(self._path, mode=mode)
         except NameError:
-            io.print('error', "h5py could not be imported")
-            raise
+            raise NameError(f'{self._path} can not be open in {mode} mode.')
         if mode == 'w':
             assert datatype in _available_types
             self._h5file.attrs.update({'cfdtools_version': __version__, 'cfd_datatype': datatype})

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,7 +4,7 @@
 
 ### Status [![PyPi Version](https://img.shields.io/pypi/v/cfdtools.svg?style=flat)](https://pypi.org/project/cfdtools)
 
-`cfdtools`  is currently mainly developed at ISAE/DAEP for IC3 pre-processing, supervised by [J. Gressier](https://github.com/jgressier). 
+`cfdtools`  is currently mainly developed at ISAE/DAEP for IC3 pre-processing, supervised by [J. Gressier](https://github.com/jgressier).
 Help and discussion are available on [![Slack](https://img.shields.io/static/v1?logo=slack&label=slack&message=contact&style=flat)](https://join.slack.com/t/isae-opendev/shared_invite/zt-obqywf6r-UUuHR4_hc5iTzyL5bFCwpw
 )
 
@@ -21,5 +21,13 @@ Development workflow is helpfully made with
 * `tox` and `pyenv` [![PyPI pyversions](https://img.shields.io/pypi/pyversions/cfdtools.svg?style=flat)](https://pypi.org/pypi/cfdtools/)
 * `pytest` and coverage tools [![codecov](https://img.shields.io/codecov/c/github/jgressier/cfdtools.svg?style=flat)](https://codecov.io/gh/jgressier/cfdtools)
 * `mkdocs` and `mkdocs-material` [![Doc](https://readthedocs.org/projects/cfdtools/badge/?version=latest)](https://cfdtools.readthedocs.io/)
+
+### Code Style
+
+[Black](https://github.com/psf/black) is used to format the code
+#### f-strings
+
+Use " " for messages and ' ' for keywords.
+Exceptions are accepted if too many escape characters are required.
 
 ## FAQ

--- a/tests/test_1_vtk.py
+++ b/tests/test_1_vtk.py
@@ -64,7 +64,28 @@ def test_vtkList_dumpxdmf(datadir, tmpdir):
     xmf_filepath = tmpdir / "vtklist.xmf"
     assert xmf_filepath.exists()
 
-    xdmf_content = '<Xdmf Version="3.0"><Domain><Grid Name="IC3" GridType="Collection" CollectionType="Temporal"><Grid Name="Unstructured Mesh"><Time Value="0"/><Geometry GeometryType="XYZ"><DataItem Dimensions="3993" Format="HDF">vtklist.hdf:/mesh/nodes</DataItem></Geometry><Topology NumberOfElements="1000" TopologyType="Hexahedron"><DataItem Dimensions="8000" Format="HDF">vtklist.hdf:/mesh/cells/hexa8</DataItem></Topology><Attribute AttributeType="Scalar" Center="Cell" Name="Q"><DataItem Dimensions="1000" Format="HDF">vtklist.hdf:/datalist/i000000/Q</DataItem></Attribute></Grid></Grid></Domain></Xdmf>'
+    xdmf_content_formatted = """
+        <Xdmf Version="3.0">
+            <Domain>
+                <Grid Name="IC3" GridType="Collection" CollectionType="Temporal">
+                    <Grid Name="Unstructured Mesh">
+                        <Time Value="0"/>
+                        <Geometry GeometryType="XYZ">
+                            <DataItem Dimensions="3993" Format="HDF">vtklist.hdf:/mesh/nodes</DataItem>
+                        </Geometry>
+                        <Topology NumberOfElements="1000" TopologyType="Hexahedron">
+                            <DataItem Dimensions="8000" Format="HDF">vtklist.hdf:/mesh/cells/hexa8</DataItem>
+                        </Topology>
+                        <Attribute AttributeType="Scalar" Center="Cell" Name="Q">
+                            <DataItem Dimensions="1000" Format="HDF">vtklist.hdf:/datalist/i000000/Q</DataItem>
+                        </Attribute>
+                    </Grid>
+                </Grid>
+            </Domain>
+        </Xdmf>
+        """
+    xdmf_content = ''.join([t.strip() for t in xdmf_content_formatted.split('\n')])
+
     lines = open(xmf_filepath, 'r').read()
     # replace end of lines with blanks
     lines = lines.replace('\n', '')


### PR DESCRIPTION
If you write an [HDF5](https://www.hdfgroup.org/) file, you can output an [XDMF](https://www.xdmf.org/) file that can be read with paraview for example.
You have to set the argument xdmf to True in the dumphdf method call.

`filename = vtklist.dumphdf("dump.h5", xdmf=True)`