### PR TITLE
fix prefix and data argument in ic3probe_plotline

### DIFF
--- a/cfdtools/_cli.py
+++ b/cfdtools/_cli.py
@@ -359,7 +359,7 @@ def ic3probe_plotline(argv=None):
     parser.parse_cli_args(argv)
     # parser.parse_filenameformat()
     # basename, ext = os.path.splitext(parser.args().filenames[0])
-    var = parser.args('datalist')[0]  # ext[1:]
+    var = parser.args('datalist')  # ext[1:]
     basename = parser.args('prefix')
     # axis must be the last to get right time size
     expected_data = [

--- a/cfdtools/probes/data.py
+++ b/cfdtools/probes/data.py
@@ -74,7 +74,7 @@ class phydata:
             success = self.read_data(varname, prefix)
         if not success:  # try to compute it
             if varname in self.dependency_vars:
-                success = np.all([self.check_data(depvar) for depvar in self.dependency_vars[varname]])
+                success = np.all([self.check_data(depvar, prefix) for depvar in self.dependency_vars[varname]])
             if success:
                 if self.verbose:
                     log.info("- compute " + varname)


### PR DESCRIPTION
ic3probe_plotline
- fix data (only the first letter was taken) option
- fix check_data in phydata class (prefix was not propagated)