### PR TITLE
doc: update documentation, fix sphere to cube

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  apt_packages:
+    - xvfb
 
 mkdocs:
   configuration: mkdocs.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,16 @@ pip show cfdtools
 
 ## Versions
 
+### [0.5.x](https://pypi.org/project/cfdtools/) (2024-xx-xx)
+
+#### fix
+
 ### [0.5.4](https://pypi.org/project/cfdtools/) (2024-02-06)
 
 #### fix
 
 - avoid failure if pyvista missing (when not necessary)
-- `probes.data`: handle non expected multiple lines in coordinate files
+- `probes.data`: handle unexpected multiple lines in coordinate files
 
 ### [0.5.3](https://pypi.org/project/cfdtools/) (2024-01-15)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ cfdtools
 
 ### Features
 
+A sum up of features follows. The documentation including examples is available there 
+[master](https://cfdtools.readthedocs.io/en/stable/)
+/[develop](https://cfdtools.readthedocs.io/en/develop/)
+
 - readers: IC3, VTK, GMSH, CGNS
 - writers: IC3, VTK
 - generic options for command line writers: extrusion

--- a/cfdtools/vtk/_vtk.py
+++ b/cfdtools/vtk/_vtk.py
@@ -126,7 +126,7 @@ class vtkMesh:
             log.warning("  no pyvista mesh available")
 
     def plot(self, background='white', show_edges=True, *args, **kwargs):
-        self.pyvista_grid().plot(background=background, show_edges=show_edges, *args, **kwargs)
+        self.pyvista_grid.plot(background=background, show_edges=show_edges, *args, **kwargs)
 
     def importhdfgroup(self, hgroup: hdf5.Group, verbose=False):
         assert hgroup.attrs['meshtype'] in ('unsmesh',)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # CFDTOOLS documentation
 
-`cfdtools` is python library dedicated to mesh pre-processing.
+`cfdtools` is python library dedicated to mesh pre- and post-processing.
 
 [![PyPi Version](https://img.shields.io/pypi/v/cfdtools.svg?style=flat)](https://pypi.org/project/cfdtools)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/cfdtools.svg?style=flat)](https://pypi.org/pypi/cfdtools/)
@@ -26,3 +26,6 @@ or clone and install `develop` branch
     git checkout develop
     pip install [--user] .
 
+## first steps
+
+`cfdtools` provides direct and simple command line tools (see [CLI](cli)). A second stage may be to directly implement you needed workflow using either these embedded tools as examples (see [sources](https://github.com/jgressier/cfdtools/blob/master/cfdtools/_cli.py)) or the [examples on this site](examples).


### PR DESCRIPTION
- restore xvfb in readthedocs configuration (lost when updating configuration in previous updates)
- fix vtk.plot when pyvista_grid was defined as a property

resolves #49 
(but will be effective with merge to master only since the documentation uses the public/published package)