### PR TITLE
Refactor sorting to avoid unnecessary sorted() calls

### DIFF
--- a/cfdtools/meshbase/_connectivity.py
+++ b/cfdtools/meshbase/_connectivity.py
@@ -277,7 +277,8 @@ class elem_connectivity:
 
     # @profile
     def exportto_compressedindex(self) -> compressed_listofindex:
-        concat = sorted(self.index_elem_tuples())
+        concat = self.index_elem_tuples()
+        concat.sort()
         nnode_perface = [len(face) for _, face in concat]
         index = np.concatenate(([0], np.cumsum(nnode_perface)))
         value = np.array(list(chain(*[face for _, face in concat])))


### PR DESCRIPTION
This pull request addresses a small performance issue by replacing unnecessary uses of `sorted()` with in-place sorting using `list.sort()` where the original list is not needed. This avoids creating an extra list and is slightly more efficient while preserving existing behavior (https://docs.python.org/3/howto/sorting.html).

The issue was identified during an ongoing research project.